### PR TITLE
docs: fix simple typo, resove -> resolve

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ else:
     extra_compiler_args=[]
 
 ##################################################################################
-# Try to resove
+# Try to resolve
 # static dependencies resolution by looking into pkgconfig files
 def static_resolver(libs):
     deps = []


### PR DESCRIPTION
There is a small typo in setup.py.

Should read `resolve` rather than `resove`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md